### PR TITLE
changed some of the data types to match the columns more accurately. …

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -8,18 +8,18 @@ DROP TABLE IF EXISTS game;
 
 CREATE TABLE game (
     id SERIAL PRIMARY KEY,
-    title VARCHAR NOT NULL,
-    genre VARCHAR(50) NOT NULL,
+    title VARCHAR(300) NOT NULL,
+    genres VARCHAR(50)[] NOT NULL,
     rating DECIMAL(3,1),
     description TEXT,
-    platform VARCHAR,
+    platforms VARCHAR[],
     boxart VARCHAR,
     esrb VARCHAR,
     subscription VARCHAR,
-    released_year INTEGER,
+    released_year VARCHAR(12),
     developer VARCHAR,
     publisher VARCHAR,
-    screenshots TEXT,
-    play_time INTEGER,
+    screenshots VARCHAR[],
+    playtime INTEGER,
     completion_time INTEGER
 )


### PR DESCRIPTION
…Genre is now genres and is an array of strings since a game can contain more than one single genre. Title now has a limit of 300 characters since the longest game title is a little less than that, I rounded up so that we can have a little bit of wiggle room in case a title ends up being any higher than that by any chance. Platform is not platforms and is an array of strings since it is available in more than one single platform. Released_year is now a string since it will be provided the day, month and year which we can later then manipulate as we like.